### PR TITLE
Implement real uploads, downloads, and persistent storage

### DIFF
--- a/src-tauri/src/dht.rs
+++ b/src-tauri/src/dht.rs
@@ -17,7 +17,10 @@ use std::{
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{
+    mpsc::{self, error::TrySendError},
+    oneshot, Mutex,
+};
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -100,8 +103,24 @@ impl DhtMetricsSnapshot {
 impl DhtMetrics {
     fn record_listen_addr(&mut self, addr: &Multiaddr) {
         let addr_str = addr.to_string();
-        if !self.listen_addrs.iter().any(|existing| existing == &addr_str) {
+        if !self
+            .listen_addrs
+            .iter()
+            .any(|existing| existing == &addr_str)
+        {
             self.listen_addrs.push(addr_str);
+        }
+    }
+}
+
+fn emit_event(event_tx: &mpsc::Sender<DhtEvent>, event: DhtEvent) {
+    match event_tx.try_send(event) {
+        Ok(()) => {}
+        Err(TrySendError::Full(event)) => {
+            warn!(?event, "Dropping DHT event because the queue is full");
+        }
+        Err(TrySendError::Closed(event)) => {
+            debug!(?event, "Dropping DHT event because the receiver closed");
         }
     }
 }
@@ -153,13 +172,19 @@ async fn run_dht_node(
                                     }
                                     Err(e) => {
                                         error!("Failed to publish file metadata {}: {}", metadata.file_hash, e);
-                                        let _ = event_tx.send(DhtEvent::Error(format!("Failed to publish: {}", e))).await;
+                                        emit_event(
+                                            &event_tx,
+                                            DhtEvent::Error(format!("Failed to publish: {}", e)),
+                                        );
                                     }
                                 }
                             }
                             Err(e) => {
                                 error!("Failed to serialize file metadata {}: {}", metadata.file_hash, e);
-                                let _ = event_tx.send(DhtEvent::Error(format!("Failed to serialize metadata: {}", e))).await;
+                                emit_event(
+                                    &event_tx,
+                                    DhtEvent::Error(format!("Failed to serialize metadata: {}", e)),
+                                );
                             }
                         }
                     }
@@ -179,12 +204,18 @@ async fn run_dht_node(
                                 }
                                 Err(e) => {
                                     error!("✗ Failed to dial {}: {}", addr, e);
-                                    let _ = event_tx.send(DhtEvent::Error(format!("Failed to connect: {}", e))).await;
+                                    emit_event(
+                                        &event_tx,
+                                        DhtEvent::Error(format!("Failed to connect: {}", e)),
+                                    );
                                 }
                             }
                         } else {
                             error!("✗ Invalid multiaddr format: {}", addr);
-                            let _ = event_tx.send(DhtEvent::Error(format!("Invalid address: {}", addr))).await;
+                            emit_event(
+                                &event_tx,
+                                DhtEvent::Error(format!("Invalid address: {}", addr)),
+                            );
                         }
                     }
                     Some(DhtCommand::GetPeerCount(tx)) => {
@@ -225,7 +256,7 @@ async fn run_dht_node(
                             m.last_success = Some(SystemTime::now());
                         }
                         info!("   Total connected peers: {}", peers_count);
-                        let _ = event_tx.send(DhtEvent::PeerConnected(peer_id.to_string())).await;
+                        emit_event(&event_tx, DhtEvent::PeerConnected(peer_id.to_string()));
                     }
                     SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
                         warn!("❌ DISCONNECTED from peer: {}", peer_id);
@@ -236,7 +267,7 @@ async fn run_dht_node(
                             peers.len()
                         };
                         info!("   Remaining connected peers: {}", peers_count);
-                        let _ = event_tx.send(DhtEvent::PeerDisconnected(peer_id.to_string())).await;
+                        emit_event(&event_tx, DhtEvent::PeerDisconnected(peer_id.to_string()));
                     }
                     SwarmEvent::NewListenAddr { address, .. } => {
                         info!("📡 Now listening on: {}", address);
@@ -265,7 +296,7 @@ async fn run_dht_node(
                         } else {
                             error!("❌ Outgoing connection error to unknown peer: {}", error);
                         }
-                        let _ = event_tx.send(DhtEvent::Error(format!("Connection failed: {}", error))).await;
+                        emit_event(&event_tx, DhtEvent::Error(format!("Connection failed: {}", error)));
                     }
                     SwarmEvent::IncomingConnectionError { error, .. } => {
                         if let Ok(mut m) = metrics.try_lock() {
@@ -310,7 +341,7 @@ async fn handle_kademlia_event(event: KademliaEvent, event_tx: &mpsc::Sender<Dht
                         if let Ok(metadata) =
                             serde_json::from_slice::<FileMetadata>(&peer_record.record.value)
                         {
-                            let _ = event_tx.send(DhtEvent::FileDiscovered(metadata)).await;
+                            emit_event(&event_tx, DhtEvent::FileDiscovered(metadata));
                         } else {
                             debug!("Received non-file metadata record");
                         }
@@ -324,7 +355,7 @@ async fn handle_kademlia_event(event: KademliaEvent, event_tx: &mpsc::Sender<Dht
                     // If the error includes the key, emit FileNotFound
                     if let kad::GetRecordError::NotFound { key, .. } = err {
                         let file_hash = String::from_utf8_lossy(key.as_ref()).to_string();
-                        let _ = event_tx.send(DhtEvent::FileNotFound(file_hash)).await;
+                        emit_event(&event_tx, DhtEvent::FileNotFound(file_hash));
                     }
                 }
                 QueryResult::PutRecord(Ok(PutRecordOk { key })) => {
@@ -332,9 +363,10 @@ async fn handle_kademlia_event(event: KademliaEvent, event_tx: &mpsc::Sender<Dht
                 }
                 QueryResult::PutRecord(Err(err)) => {
                     warn!("PutRecord error: {:?}", err);
-                    let _ = event_tx
-                        .send(DhtEvent::Error(format!("PutRecord failed: {:?}", err)))
-                        .await;
+                    emit_event(
+                        &event_tx,
+                        DhtEvent::Error(format!("PutRecord failed: {:?}", err)),
+                    );
                 }
                 _ => {}
             }
@@ -376,9 +408,7 @@ async fn handle_mdns_event(
                     .behaviour_mut()
                     .kademlia
                     .add_address(&peer_id, multiaddr);
-                let _ = event_tx
-                    .send(DhtEvent::PeerDiscovered(peer_id.to_string()))
-                    .await;
+                emit_event(&event_tx, DhtEvent::PeerDiscovered(peer_id.to_string()));
             }
         }
         MdnsEvent::Expired(list) => {
@@ -657,13 +687,10 @@ mod tests {
     #[test]
     fn metrics_snapshot_carries_listen_addrs() {
         let mut metrics = DhtMetrics::default();
-        metrics
-            .record_listen_addr(&"/ip4/127.0.0.1/tcp/4001".parse::<Multiaddr>().unwrap());
-        metrics
-            .record_listen_addr(&"/ip4/0.0.0.0/tcp/4001".parse::<Multiaddr>().unwrap());
+        metrics.record_listen_addr(&"/ip4/127.0.0.1/tcp/4001".parse::<Multiaddr>().unwrap());
+        metrics.record_listen_addr(&"/ip4/0.0.0.0/tcp/4001".parse::<Multiaddr>().unwrap());
         // Duplicate should be ignored
-        metrics
-            .record_listen_addr(&"/ip4/127.0.0.1/tcp/4001".parse::<Multiaddr>().unwrap());
+        metrics.record_listen_addr(&"/ip4/127.0.0.1/tcp/4001".parse::<Multiaddr>().unwrap());
 
         let snapshot = DhtMetricsSnapshot::from(metrics, 5);
         assert_eq!(snapshot.peer_count, 5);

--- a/src-tauri/src/file_transfer.rs
+++ b/src-tauri/src/file_transfer.rs
@@ -319,9 +319,7 @@ impl FileTransferState {
     async fn assemble_file(&self, file_hash: &str, output_path: &Path) -> Result<(), String> {
         let manifest = {
             let guard = self.stored_files.lock().await;
-            guard
-                .get(file_hash)
-                .cloned()
+            guard.get(file_hash).cloned()
         }
         .ok_or_else(|| "File not found locally".to_string())?;
 
@@ -405,7 +403,11 @@ impl FileTransferService {
         });
 
         // Spawn the file transfer service task
-        tokio::spawn(Self::run_file_transfer_service(cmd_rx, event_tx, state.clone()));
+        tokio::spawn(Self::run_file_transfer_service(
+            cmd_rx,
+            event_tx,
+            state.clone(),
+        ));
 
         Ok(FileTransferService {
             cmd_tx,
@@ -414,7 +416,9 @@ impl FileTransferService {
         })
     }
 
-    async fn load_existing_manifests(manifests_dir: &Path) -> Result<HashMap<String, StoredFile>, String> {
+    async fn load_existing_manifests(
+        manifests_dir: &Path,
+    ) -> Result<HashMap<String, StoredFile>, String> {
         let mut stored_files = HashMap::new();
 
         let mut entries = match fs::read_dir(manifests_dir).await {
@@ -498,7 +502,8 @@ impl FileTransferService {
                     output_path,
                     respond_to,
                 } => {
-                    match Self::handle_download_file(&file_hash, &output_path, state.clone()).await {
+                    match Self::handle_download_file(&file_hash, &output_path, state.clone()).await
+                    {
                         Ok(()) => {
                             let _ = respond_to.send(Ok(()));
                             let _ = event_tx
@@ -536,9 +541,7 @@ impl FileTransferService {
         file_name: &str,
         state: Arc<FileTransferState>,
     ) -> Result<String, String> {
-        state
-            .store_from_path(Path::new(file_path), file_name)
-            .await
+        state.store_from_path(Path::new(file_path), file_name).await
     }
 
     async fn handle_download_file(
@@ -546,9 +549,7 @@ impl FileTransferService {
         output_path: &str,
         state: Arc<FileTransferState>,
     ) -> Result<(), String> {
-        state
-            .assemble_file(file_hash, Path::new(output_path))
-            .await
+        state.assemble_file(file_hash, Path::new(output_path)).await
     }
 
     pub fn calculate_file_hash(data: &[u8]) -> String {
@@ -557,7 +558,11 @@ impl FileTransferService {
         format!("{:x}", hasher.finalize())
     }
 
-    pub async fn upload_file(&self, file_path: String, file_name: String) -> Result<String, String> {
+    pub async fn upload_file(
+        &self,
+        file_path: String,
+        file_name: String,
+    ) -> Result<String, String> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(FileTransferCommand::UploadFile {
@@ -609,7 +614,11 @@ impl FileTransferService {
         events
     }
 
-    pub async fn store_file_data(&self, file_name: String, file_data: Vec<u8>) -> Result<String, String> {
+    pub async fn store_file_data(
+        &self,
+        file_name: String,
+        file_data: Vec<u8>,
+    ) -> Result<String, String> {
         self.state.store_from_bytes(&file_name, &file_data).await
     }
 }

--- a/src-tauri/src/file_transfer.rs
+++ b/src-tauri/src/file_transfer.rs
@@ -1,8 +1,17 @@
+use aes_gcm::aead::{Aead, OsRng};
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use directories::ProjectDirs;
+use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
-use tracing::{debug, error, info};
+use tokio::fs;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileRequest {
@@ -24,10 +33,12 @@ pub enum FileTransferCommand {
     UploadFile {
         file_path: String,
         file_name: String,
+        respond_to: oneshot::Sender<Result<String, String>>,
     },
     DownloadFile {
         file_hash: String,
         output_path: String,
+        respond_to: oneshot::Sender<Result<(), String>>,
     },
     GetStoredFiles,
 }
@@ -49,44 +60,420 @@ pub enum FileTransferEvent {
     },
 }
 
+const CHUNK_SIZE: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkMetadata {
+    pub index: u32,
+    pub hash: String,
+    pub size: u64,
+    pub stored_size: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncryptionMetadata {
+    pub algorithm: String,
+    pub nonce_size: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompressionMetadata {
+    pub algorithm: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredFile {
+    pub file_hash: String,
+    pub file_name: String,
+    pub file_size: u64,
+    pub chunk_size: u64,
+    pub chunks: Vec<ChunkMetadata>,
+    pub encryption: Option<EncryptionMetadata>,
+    pub compression: Option<CompressionMetadata>,
+    pub created_at: u64,
+}
+
+#[derive(Debug, Clone)]
+struct StorageConfig {
+    encrypt_chunks: bool,
+    compression: bool,
+    encryption_key: Option<[u8; 32]>,
+}
+
+impl StorageConfig {
+    fn encryption_metadata(&self) -> Option<EncryptionMetadata> {
+        if self.encrypt_chunks {
+            Some(EncryptionMetadata {
+                algorithm: "AES-256-GCM".to_string(),
+                nonce_size: 12,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn compression_metadata(&self) -> Option<CompressionMetadata> {
+        if self.compression {
+            Some(CompressionMetadata {
+                algorithm: "zlib".to_string(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
 pub struct FileTransferService {
     cmd_tx: mpsc::Sender<FileTransferCommand>,
     event_rx: Arc<Mutex<mpsc::Receiver<FileTransferEvent>>>,
-    stored_files: Arc<Mutex<HashMap<String, (String, Vec<u8>)>>>, // hash -> (name, data)
+    state: Arc<FileTransferState>,
+}
+
+#[derive(Debug)]
+struct FileTransferState {
+    stored_files: Mutex<HashMap<String, StoredFile>>,
+    storage_root: PathBuf,
+    chunks_dir: PathBuf,
+    manifests_dir: PathBuf,
+    config: StorageConfig,
+}
+
+impl FileTransferState {
+    async fn store_from_path(&self, file_path: &Path, file_name: &str) -> Result<String, String> {
+        let mut file = fs::File::open(file_path)
+            .await
+            .map_err(|e| format!("Failed to read file: {}", e))?;
+        let mut buffer = vec![0u8; CHUNK_SIZE];
+        let mut hasher = Sha256::new();
+        let mut total_size = 0u64;
+        let mut chunk_index: u32 = 0;
+        let mut chunks = Vec::new();
+
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .await
+                .map_err(|e| format!("Failed to read file chunk: {}", e))?;
+            if read == 0 {
+                break;
+            }
+
+            let chunk_data = &buffer[..read];
+            total_size += read as u64;
+            hasher.update(chunk_data);
+            let chunk_hash = Self::hash_chunk(chunk_data);
+            let stored_size = self.persist_chunk(&chunk_hash, chunk_data).await?;
+            chunks.push(ChunkMetadata {
+                index: chunk_index,
+                hash: chunk_hash,
+                size: read as u64,
+                stored_size,
+            });
+            chunk_index += 1;
+        }
+
+        let file_hash = format!("{:x}", hasher.finalize());
+        self.persist_manifest(file_hash, file_name, total_size, chunks)
+            .await
+    }
+
+    async fn store_from_bytes(&self, file_name: &str, data: &[u8]) -> Result<String, String> {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        let file_hash = format!("{:x}", hasher.finalize());
+
+        let mut chunks = Vec::new();
+        let mut chunk_index: u32 = 0;
+        let mut offset = 0usize;
+
+        while offset < data.len() {
+            let end = (offset + CHUNK_SIZE).min(data.len());
+            let chunk_data = &data[offset..end];
+            let chunk_hash = Self::hash_chunk(chunk_data);
+            let stored_size = self.persist_chunk(&chunk_hash, chunk_data).await?;
+            chunks.push(ChunkMetadata {
+                index: chunk_index,
+                hash: chunk_hash,
+                size: chunk_data.len() as u64,
+                stored_size,
+            });
+            chunk_index += 1;
+            offset = end;
+        }
+
+        self.persist_manifest(file_hash, file_name, data.len() as u64, chunks)
+            .await
+    }
+
+    async fn persist_manifest(
+        &self,
+        file_hash: String,
+        file_name: &str,
+        file_size: u64,
+        chunks: Vec<ChunkMetadata>,
+    ) -> Result<String, String> {
+        let manifest = StoredFile {
+            file_hash: file_hash.clone(),
+            file_name: file_name.to_string(),
+            file_size,
+            chunk_size: CHUNK_SIZE as u64,
+            chunks,
+            encryption: self.config.encryption_metadata(),
+            compression: self.config.compression_metadata(),
+            created_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_err(|e| format!("Failed to compute timestamp: {}", e))?
+                .as_secs(),
+        };
+
+        let manifest_path = self
+            .manifests_dir
+            .join(format!("{}.json", manifest.file_hash));
+        let payload = serde_json::to_vec_pretty(&manifest)
+            .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
+        fs::write(&manifest_path, payload)
+            .await
+            .map_err(|e| format!("Failed to write manifest: {}", e))?;
+
+        let mut guard = self.stored_files.lock().await;
+        guard.insert(manifest.file_hash.clone(), manifest);
+
+        Ok(file_hash)
+    }
+
+    async fn persist_chunk(&self, chunk_hash: &str, data: &[u8]) -> Result<u64, String> {
+        let chunk_path = self.chunks_dir.join(chunk_hash);
+        if let Ok(metadata) = fs::metadata(&chunk_path).await {
+            return Ok(metadata.len());
+        }
+
+        let encoded = self.encode_chunk(data)?;
+        fs::write(&chunk_path, &encoded)
+            .await
+            .map_err(|e| format!("Failed to write chunk {}: {}", chunk_hash, e))?;
+        Ok(encoded.len() as u64)
+    }
+
+    fn encode_chunk(&self, data: &[u8]) -> Result<Vec<u8>, String> {
+        let mut payload = if self.config.compression {
+            self.compress_chunk(data)?
+        } else {
+            data.to_vec()
+        };
+
+        if self.config.encrypt_chunks {
+            let key = self
+                .config
+                .encryption_key
+                .as_ref()
+                .ok_or_else(|| "Encryption key not configured".to_string())?;
+            let cipher = Aes256Gcm::new(Key::from_slice(key));
+            let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+            let mut encrypted = cipher
+                .encrypt(&nonce, payload.as_ref())
+                .map_err(|e| format!("Chunk encryption failed: {}", e))?;
+            let mut combined = nonce.to_vec();
+            combined.append(&mut encrypted);
+            Ok(combined)
+        } else {
+            Ok(payload)
+        }
+    }
+
+    fn decode_chunk(
+        &self,
+        data: Vec<u8>,
+        encrypted: bool,
+        compressed: bool,
+    ) -> Result<Vec<u8>, String> {
+        let mut payload = data;
+
+        if encrypted {
+            let key = self
+                .config
+                .encryption_key
+                .as_ref()
+                .ok_or_else(|| "Encryption key not configured".to_string())?;
+            if payload.len() < 12 {
+                return Err("Encrypted chunk is too small to contain a nonce".to_string());
+            }
+            let (nonce_bytes, ciphertext) = payload.split_at(12);
+            let cipher = Aes256Gcm::new(Key::from_slice(key));
+            payload = cipher
+                .decrypt(Nonce::from_slice(nonce_bytes), ciphertext)
+                .map_err(|e| format!("Chunk decryption failed: {}", e))?;
+        }
+
+        if compressed {
+            let mut decoder = ZlibDecoder::new(&payload[..]);
+            let mut decompressed = Vec::new();
+            decoder
+                .read_to_end(&mut decompressed)
+                .map_err(|e| format!("Chunk decompression failed: {}", e))?;
+            Ok(decompressed)
+        } else {
+            Ok(payload)
+        }
+    }
+
+    async fn assemble_file(&self, file_hash: &str, output_path: &Path) -> Result<(), String> {
+        let manifest = {
+            let guard = self.stored_files.lock().await;
+            guard
+                .get(file_hash)
+                .cloned()
+        }
+        .ok_or_else(|| "File not found locally".to_string())?;
+
+        let encrypted = manifest.encryption.is_some();
+        let compressed = manifest.compression.is_some();
+
+        let mut output = fs::File::create(output_path)
+            .await
+            .map_err(|e| format!("Failed to create {}: {}", output_path.display(), e))?;
+
+        for chunk in manifest.chunks {
+            let chunk_path = self.chunks_dir.join(&chunk.hash);
+            let raw = fs::read(&chunk_path)
+                .await
+                .map_err(|e| format!("Failed to read chunk {}: {}", chunk.hash, e))?;
+            let decoded = self.decode_chunk(raw, encrypted, compressed)?;
+            if decoded.len() as u64 != chunk.size {
+                return Err(format!(
+                    "Chunk {} size mismatch (expected {}, got {})",
+                    chunk.index,
+                    chunk.size,
+                    decoded.len()
+                ));
+            }
+            output
+                .write_all(&decoded)
+                .await
+                .map_err(|e| format!("Failed to write chunk {}: {}", chunk.index, e))?;
+        }
+
+        Ok(())
+    }
+
+    fn compress_chunk(&self, data: &[u8]) -> Result<Vec<u8>, String> {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(data)
+            .map_err(|e| format!("Compression failed: {}", e))?;
+        encoder
+            .finish()
+            .map_err(|e| format!("Compression finalize failed: {}", e))
+    }
+
+    fn hash_chunk(data: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        format!("{:x}", hasher.finalize())
+    }
 }
 
 impl FileTransferService {
     pub async fn new() -> Result<Self, String> {
         let (cmd_tx, cmd_rx) = mpsc::channel(100);
         let (event_tx, event_rx) = mpsc::channel(100);
-        let stored_files = Arc::new(Mutex::new(HashMap::new()));
+        let project_dirs = ProjectDirs::from("com", "Chiral", "ChiralNetwork")
+            .ok_or_else(|| "Unable to determine storage directory".to_string())?;
+
+        let storage_root = PathBuf::from(project_dirs.data_dir());
+        let chunks_dir = storage_root.join("chunks");
+        let manifests_dir = storage_root.join("manifests");
+
+        fs::create_dir_all(&chunks_dir)
+            .await
+            .map_err(|e| format!("Failed to create chunks directory: {}", e))?;
+        fs::create_dir_all(&manifests_dir)
+            .await
+            .map_err(|e| format!("Failed to create manifests directory: {}", e))?;
+
+        let stored_files_map = Self::load_existing_manifests(&manifests_dir).await?;
+
+        let state = Arc::new(FileTransferState {
+            stored_files: Mutex::new(stored_files_map),
+            storage_root,
+            chunks_dir,
+            manifests_dir,
+            config: StorageConfig {
+                encrypt_chunks: false,
+                compression: false,
+                encryption_key: None,
+            },
+        });
 
         // Spawn the file transfer service task
-        tokio::spawn(Self::run_file_transfer_service(
-            cmd_rx,
-            event_tx,
-            stored_files.clone(),
-        ));
+        tokio::spawn(Self::run_file_transfer_service(cmd_rx, event_tx, state.clone()));
 
         Ok(FileTransferService {
             cmd_tx,
             event_rx: Arc::new(Mutex::new(event_rx)),
-            stored_files,
+            state,
         })
+    }
+
+    async fn load_existing_manifests(manifests_dir: &Path) -> Result<HashMap<String, StoredFile>, String> {
+        let mut stored_files = HashMap::new();
+
+        let mut entries = match fs::read_dir(manifests_dir).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(stored_files),
+            Err(e) => {
+                return Err(format!(
+                    "Failed to read manifests directory {}: {}",
+                    manifests_dir.display(),
+                    e
+                ))
+            }
+        };
+
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|e| format!("Failed to iterate manifests: {}", e))?
+        {
+            let path = entry.path();
+            if entry
+                .file_type()
+                .await
+                .map_err(|e| format!("Failed to inspect {:?}: {}", path, e))?
+                .is_file()
+            {
+                match fs::read(&path).await {
+                    Ok(bytes) => match serde_json::from_slice::<StoredFile>(&bytes) {
+                        Ok(manifest) => {
+                            stored_files.insert(manifest.file_hash.clone(), manifest);
+                        }
+                        Err(e) => {
+                            warn!("Ignoring corrupt manifest {:?}: {}", path, e);
+                        }
+                    },
+                    Err(e) => {
+                        warn!("Failed to load manifest {:?}: {}", path, e);
+                    }
+                }
+            }
+        }
+
+        Ok(stored_files)
     }
 
     async fn run_file_transfer_service(
         mut cmd_rx: mpsc::Receiver<FileTransferCommand>,
         event_tx: mpsc::Sender<FileTransferEvent>,
-        stored_files: Arc<Mutex<HashMap<String, (String, Vec<u8>)>>>,
+        state: Arc<FileTransferState>,
     ) {
         while let Some(cmd) = cmd_rx.recv().await {
             match cmd {
                 FileTransferCommand::UploadFile {
                     file_path,
                     file_name,
-                } => match Self::handle_upload_file(&file_path, &file_name, &stored_files).await {
+                    respond_to,
+                } => match Self::handle_upload_file(&file_path, &file_name, state.clone()).await {
                     Ok(file_hash) => {
+                        let _ = respond_to.send(Ok(file_hash.clone()));
                         let _ = event_tx
                             .send(FileTransferEvent::FileUploaded {
                                 file_hash: file_hash.clone(),
@@ -96,6 +483,7 @@ impl FileTransferService {
                         info!("File uploaded successfully: {} -> {}", file_name, file_hash);
                     }
                     Err(e) => {
+                        let _ = respond_to.send(Err(e.clone()));
                         let error_msg = format!("Upload failed: {}", e);
                         let _ = event_tx
                             .send(FileTransferEvent::Error {
@@ -108,10 +496,11 @@ impl FileTransferService {
                 FileTransferCommand::DownloadFile {
                     file_hash,
                     output_path,
+                    respond_to,
                 } => {
-                    match Self::handle_download_file(&file_hash, &output_path, &stored_files).await
-                    {
+                    match Self::handle_download_file(&file_hash, &output_path, state.clone()).await {
                         Ok(()) => {
+                            let _ = respond_to.send(Ok(()));
                             let _ = event_tx
                                 .send(FileTransferEvent::FileDownloaded {
                                     file_path: output_path.clone(),
@@ -123,6 +512,7 @@ impl FileTransferService {
                             );
                         }
                         Err(e) => {
+                            let _ = respond_to.send(Err(e.clone()));
                             let error_msg = format!("Download failed: {}", e);
                             let _ = event_tx
                                 .send(FileTransferEvent::Error {
@@ -144,63 +534,40 @@ impl FileTransferService {
     async fn handle_upload_file(
         file_path: &str,
         file_name: &str,
-        stored_files: &Arc<Mutex<HashMap<String, (String, Vec<u8>)>>>,
+        state: Arc<FileTransferState>,
     ) -> Result<String, String> {
-        // Read the file
-        let file_data = tokio::fs::read(file_path)
+        state
+            .store_from_path(Path::new(file_path), file_name)
             .await
-            .map_err(|e| format!("Failed to read file: {}", e))?;
-
-        // Calculate file hash
-        let file_hash = Self::calculate_file_hash(&file_data);
-
-        // Store the file in memory (in a real implementation, this would be persistent storage)
-        {
-            let mut files = stored_files.lock().await;
-            files.insert(file_hash.clone(), (file_name.to_string(), file_data));
-        }
-
-        Ok(file_hash)
     }
 
     async fn handle_download_file(
         file_hash: &str,
         output_path: &str,
-        stored_files: &Arc<Mutex<HashMap<String, (String, Vec<u8>)>>>,
+        state: Arc<FileTransferState>,
     ) -> Result<(), String> {
-        // Check if we have the file locally
-        let (file_name, file_data) = {
-            let files = stored_files.lock().await;
-            files
-                .get(file_hash)
-                .ok_or_else(|| "File not found locally".to_string())?
-                .clone()
-        };
-
-        // Write the file to the output path
-        tokio::fs::write(output_path, file_data)
+        state
+            .assemble_file(file_hash, Path::new(output_path))
             .await
-            .map_err(|e| format!("Failed to write file: {}", e))?;
-
-        info!("File downloaded: {} -> {}", file_name, output_path);
-        Ok(())
     }
 
     pub fn calculate_file_hash(data: &[u8]) -> String {
-        use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(data);
         format!("{:x}", hasher.finalize())
     }
 
-    pub async fn upload_file(&self, file_path: String, file_name: String) -> Result<(), String> {
+    pub async fn upload_file(&self, file_path: String, file_name: String) -> Result<String, String> {
+        let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(FileTransferCommand::UploadFile {
                 file_path,
                 file_name,
+                respond_to: tx,
             })
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        rx.await.map_err(|e| e.to_string())?
     }
 
     pub async fn download_file(
@@ -208,20 +575,23 @@ impl FileTransferService {
         file_hash: String,
         output_path: String,
     ) -> Result<(), String> {
+        let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(FileTransferCommand::DownloadFile {
                 file_hash,
                 output_path,
+                respond_to: tx,
             })
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        rx.await.map_err(|e| e.to_string())?
     }
 
     pub async fn get_stored_files(&self) -> Result<Vec<(String, String)>, String> {
-        let files = self.stored_files.lock().await;
+        let files = self.state.stored_files.lock().await;
         Ok(files
             .iter()
-            .map(|(hash, (name, _))| (hash.clone(), name.clone()))
+            .map(|(hash, manifest)| (hash.clone(), manifest.file_name.clone()))
             .collect())
     }
 
@@ -239,8 +609,7 @@ impl FileTransferService {
         events
     }
 
-    pub async fn store_file_data(&self, file_hash: String, file_name: String, file_data: Vec<u8>) {
-        let mut stored_files = self.stored_files.lock().await;
-        stored_files.insert(file_hash, (file_name, file_data));
+    pub async fn store_file_data(&self, file_name: String, file_data: Vec<u8>) -> Result<String, String> {
+        self.state.store_from_bytes(&file_name, &file_data).await
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -559,9 +559,7 @@ async fn upload_file_to_network(
     };
 
     if let Some(ft) = ft {
-        let file_hash = ft
-            .upload_file(file_path.clone(), file_name.clone())
-            .await?;
+        let file_hash = ft.upload_file(file_path.clone(), file_name.clone()).await?;
 
         // Also publish to DHT if it's running
         let dht = {
@@ -641,9 +639,7 @@ async fn upload_file_data_to_network(
 
     if let Some(ft) = ft {
         let file_size = file_data.len() as u64;
-        let file_hash = ft
-            .store_file_data(file_name.clone(), file_data)
-            .await?;
+        let file_hash = ft.store_file_data(file_name.clone(), file_data).await?;
 
         // Also publish to DHT if it's running
         let dht = {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -559,14 +559,9 @@ async fn upload_file_to_network(
     };
 
     if let Some(ft) = ft {
-        // Upload the file
-        ft.upload_file(file_path.clone(), file_name.clone()).await?;
-
-        // Get the file hash by reading the file and calculating it
-        let file_data = tokio::fs::read(&file_path)
-            .await
-            .map_err(|e| format!("Failed to read file: {}", e))?;
-        let file_hash = file_transfer::FileTransferService::calculate_file_hash(&file_data);
+        let file_hash = ft
+            .upload_file(file_path.clone(), file_name.clone())
+            .await?;
 
         // Also publish to DHT if it's running
         let dht = {
@@ -645,13 +640,10 @@ async fn upload_file_data_to_network(
     };
 
     if let Some(ft) = ft {
-        // Calculate file hash from the data
-        let file_hash = file_transfer::FileTransferService::calculate_file_hash(&file_data);
-
-        // Store the file data directly in memory
         let file_size = file_data.len() as u64;
-        ft.store_file_data(file_hash.clone(), file_name.clone(), file_data)
-            .await;
+        let file_hash = ft
+            .store_file_data(file_name.clone(), file_data)
+            .await?;
 
         // Also publish to DHT if it's running
         let dht = {

--- a/src/lib/components/TransactionList.svelte
+++ b/src/lib/components/TransactionList.svelte
@@ -15,7 +15,6 @@
   } from 'lucide-svelte'
   import { t } from 'svelte-i18n'
   import { get } from 'svelte/store'
-  import { showToast } from '$lib/toast'
 
   const tr = (k: string, params?: Record<string, any>) => get(t)(k, params)
 
@@ -181,24 +180,24 @@
 
         <!-- Filters -->
         <div class="flex gap-2">
-          <DropDown
-            options={statusOptions}
-            bind:value={statusFilter}
-            placeholder="Status"
-            class="min-w-[120px]"
-          />
-          <DropDown
-            options={typeOptions}
-            bind:value={typeFilter}
-            placeholder="Type"
-            class="min-w-[120px]"
-          />
-          <DropDown
-            options={sortOptions}
-            bind:value={sortBy}
-            placeholder="Sort by"
-            class="min-w-[120px]"
-          />
+          <div class="min-w-[120px]">
+            <DropDown
+              options={statusOptions}
+              bind:value={statusFilter}
+            />
+          </div>
+          <div class="min-w-[120px]">
+            <DropDown
+              options={typeOptions}
+              bind:value={typeFilter}
+            />
+          </div>
+          <div class="min-w-[120px]">
+            <DropDown
+              options={sortOptions}
+              bind:value={sortBy}
+            />
+          </div>
           <Button
             variant="outline"
             size="sm"
@@ -234,18 +233,18 @@
       </Card>
     {:else}
       {#each filteredTransactions as tx (tx.id)}
-        <Card 
-          class="p-4 hover:bg-gray-50 dark:hover:bg-gray-800/50 cursor-pointer transition-colors"
-          on:click={() => handleTransactionClick(tx)}
-          on:keydown={(e) => {
-            if (e.key === 'Enter') {
-              handleTransactionClick(tx)
-            }
-          }}
-          role="button"
-          tabindex="0"
-        >
-          <div class="flex items-center justify-between">
+        <Card class="p-4 transition-colors">
+          <div
+            class="flex items-center justify-between cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"
+            role="button"
+            tabindex="0"
+            on:click={() => handleTransactionClick(tx)}
+            on:keydown={(event: KeyboardEvent) => {
+              if (event.key === 'Enter') {
+                handleTransactionClick(tx)
+              }
+            }}
+          >
             <!-- Left side: Type, Description, Address -->
             <div class="flex items-center space-x-3 flex-1 min-w-0">
               <!-- Type Icon -->

--- a/src/lib/services/fileService.ts
+++ b/src/lib/services/fileService.ts
@@ -64,9 +64,9 @@ export class FileService {
    * @param fileName The name to save the file as.
    * @returns The full path to the downloaded file.
    */
-  async downloadFile(hash: string, fileName: string): Promise<string> {
+  async downloadFile(hash: string, fileName: string, destinationPath?: string): Promise<string> {
     const downloadPath = await downloadDir();
-    const outputPath = await join(downloadPath, fileName);
+    const outputPath = destinationPath ?? (await join(downloadPath, fileName));
 
     // Calls 'download_file_from_network' on the backend.
     // Note: The current backend implementation only retrieves from its local

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -111,35 +111,7 @@ export interface BlacklistEntry {
 }
 
 // Sample dummy data
-const dummyFiles: FileItem[] = [
-  {
-    id: "0",
-    name: "Video.mp4",
-    hash: "QmZ4tDuvesekqMF",
-    size: 50331648,
-    status: "paused",
-    progress: 30,
-    visualOrder: 1,
-  },
-  {
-    id: "1",
-    name: "Document.pdf",
-    hash: "QmZ4tDuvesekqMD",
-    size: 2048576,
-    status: "completed",
-    progress: 100,
-    visualOrder: 2,
-  },
-  {
-    id: "2",
-    name: "Archive.zip",
-    hash: "QmZ4tDuvesekqMG",
-    size: 10485760,
-    status: "uploaded",
-    progress: 100,
-    visualOrder: 3,
-  },
-];
+const dummyFiles: FileItem[] = [];
 
 const dummyProxyNodes: ProxyNode[] = [
   {

--- a/src/pages/Account.svelte
+++ b/src/pages/Account.svelte
@@ -5,9 +5,9 @@
   import Label from '$lib/components/ui/label.svelte'
   import { Wallet, Copy, ArrowUpRight, ArrowDownLeft, History, Coins, Plus, Import, BadgeX, KeyRound, FileText } from 'lucide-svelte'
   import DropDown from "$lib/components/ui/dropDown.svelte";
-  import { wallet, etcAccount, blacklist} from '$lib/stores' 
-  import { transactions, type Transaction } from '$lib/stores';
-  import { writable, derived } from 'svelte/store'
+  import { wallet, etcAccount, blacklist} from '$lib/stores'
+  import { transactions } from '$lib/stores';
+  import { derived } from 'svelte/store'
   import { invoke } from '@tauri-apps/api/core'
   import QRCode from 'qrcode'
   import { Html5QrcodeScanner as Html5QrcodeScannerClass } from 'html5-qrcode'
@@ -24,8 +24,6 @@
   import AccountList from '$lib/components/wallet/AccountList.svelte'
   // HD helpers are used within MnemonicWizard/AccountList components
 
-  // Transaction components
-  import TransactionList from '$lib/components/TransactionList.svelte'
   import TransactionReceipt from '$lib/components/TransactionReceipt.svelte'
 
 
@@ -1634,7 +1632,7 @@
               <div class="h-1 flex-1 bg-gray-200 rounded-full overflow-hidden">
                 <div
                   class="h-full transition-all duration-300 {passwordStrength === 'strong' ? 'bg-green-500 w-full' : passwordStrength === 'medium' ? 'bg-yellow-500 w-2/3' : 'bg-red-500 w-1/3'}"
-                />
+                ></div>
               </div>
               <span class="text-xs {passwordStrength === 'strong' ? 'text-green-600' : passwordStrength === 'medium' ? 'text-yellow-600' : 'text-red-600'}">
                 {passwordFeedback}

--- a/src/pages/Download.svelte
+++ b/src/pages/Download.svelte
@@ -5,10 +5,13 @@
   import Label from '$lib/components/ui/label.svelte'
   import Badge from '$lib/components/ui/badge.svelte'
   import Progress from '$lib/components/ui/progress.svelte'
-  import { Search, Pause, Play, X, ChevronUp, ChevronDown, Settings, FolderOpen, Star, Zap, File as FileIcon, FileText, FileImage, FileVideo, FileAudio, Archive, Code, FileSpreadsheet, Presentation } from 'lucide-svelte'
+  import { Search, Pause, Play, X, ChevronUp, ChevronDown, Settings, FolderOpen, File as FileIcon, FileText, FileImage, FileVideo, FileAudio, Archive, Code, FileSpreadsheet, Presentation } from 'lucide-svelte'
   import { files, downloadQueue } from '$lib/stores'
   import { t } from 'svelte-i18n'
   import { get } from 'svelte/store'
+  import { onMount } from 'svelte'
+  import { fileService } from '$lib/services/fileService'
+  import { dhtService } from '$lib/dht'
   const tr = (k: string, params?: Record<string, any>) => get(t)(k, params)
   
   let searchHash = ''  // For downloading new files
@@ -19,13 +22,25 @@
   let filterStatus = 'all' // 'all', 'active', 'paused', 'queued', 'completed', 'failed'
   let activeSimulations = new Set<string>() // Track files with active progress simulations
 
+  interface SearchResult {
+    fileHash: string
+    fileName: string
+    fileSize: number
+    seeders: number
+    leechers: number
+  }
+
   // New state for search results
-  let searchResults: any[] = []
+  let searchResults: SearchResult[] = []
   let isSearching = false
   let hasSearched = false
 
   // Add notification related variables
   let currentNotification: HTMLElement | null = null
+
+  let pendingSearchHash: string | null = null
+  const discoveredResults = new Map<string, SearchResult>()
+  let pollTimer: ReturnType<typeof setInterval> | null = null
 
   // Show notification function
   function showNotification(message: string, type: 'success' | 'error' | 'info' | 'warning' = 'success', duration = 4000) {
@@ -103,6 +118,80 @@
       }
     }, duration)
   }
+
+  function handleFileDiscovered(hash: string, name: string, sizeText: string) {
+    const size = Number(sizeText)
+    const normalizedName = name || `File-${hash.slice(0, 8)}`
+    const existing = discoveredResults.get(hash)
+    const next: SearchResult = existing
+      ? { ...existing, fileName: normalizedName, fileSize: Number.isFinite(size) ? size : existing.fileSize }
+      : {
+          fileHash: hash,
+          fileName: normalizedName,
+          fileSize: Number.isFinite(size) ? size : 0,
+          seeders: 1,
+          leechers: 0
+        }
+
+    discoveredResults.set(hash, next)
+
+    if (pendingSearchHash && pendingSearchHash === hash) {
+      searchResults = [next]
+      isSearching = false
+      hasSearched = true
+      pendingSearchHash = null
+      showNotification(`Found file ${next.fileName}`, 'success', 2500)
+    } else if (!pendingSearchHash) {
+      searchResults = Array.from(discoveredResults.values())
+    }
+  }
+
+  function handleFileNotFound(hash: string) {
+    if (pendingSearchHash && pendingSearchHash === hash) {
+      isSearching = false
+      hasSearched = true
+      searchResults = []
+      pendingSearchHash = null
+      showNotification(`No peers reported file ${hash}`, 'warning', 4000)
+    }
+  }
+
+  async function pollDhtEvents() {
+    try {
+      const events = await dhtService.getEvents()
+      for (const event of events) {
+        if (event.startsWith('file_discovered:')) {
+          const parts = event.split(':')
+          const hash = parts[1]
+          const sizeText = parts.at(-1) ?? '0'
+          const name = parts.slice(2, -1).join(':')
+          handleFileDiscovered(hash, name, sizeText)
+        } else if (event.startsWith('file_not_found:')) {
+          const [, hash] = event.split(':', 2)
+          handleFileNotFound(hash)
+        } else if (event.startsWith('error:')) {
+          const [, message] = event.split(':', 2)
+          showNotification(message || 'DHT reported an error', 'error', 6000)
+        }
+      }
+    } catch (error) {
+      console.error('Failed to read DHT events', error)
+    }
+  }
+
+  onMount(() => {
+    pollTimer = setInterval(() => {
+      pollDhtEvents()
+    }, 1500)
+    pollDhtEvents()
+
+    return () => {
+      if (pollTimer) {
+        clearInterval(pollTimer)
+        pollTimer = null
+      }
+    }
+  })
 
   function getFileIcon(fileName: string) {
     const extension = fileName.split('.').pop()?.toLowerCase() || '';
@@ -329,117 +418,29 @@
     isSearching = true
     searchResults = []
     hasSearched = false
+    const trimmed = searchHash.trim()
+    if (!trimmed) {
+      isSearching = false
+      showNotification(tr('download.notifications.enterHash'), 'warning')
+      return
+    }
+    pendingSearchHash = trimmed
+    discoveredResults.delete(trimmed)
 
     try {
-      // Show search start notification
       showNotification('Searching for file in network...', 'info', 2000)
-
-      // Simulate search delay for realistic UX
-      await new Promise(resolve => setTimeout(resolve, 1500));
-
-      // Mock file database with predefined hashes for testing
-      // TODO: Replace with actual DHT search results
-      const mockFileDatabase = {
-        // Existing files (already in downloads list)
-        'QmZ4tDuvesekqMF': {
-          fileName: 'Video.mp4',
-          fileSize: 50331648, // 48.00 MB
-          peers: [
-            { id: 'peer1', nickname: 'AliceNode', reputation: 4.8, status: 'online', connection: 'fast' },
-            { id: 'peer2', nickname: 'BobStorage', reputation: 4.5, status: 'online', connection: 'average' }
-          ]
-        },
-        'QmZ4tDuvesekqMD': {
-          fileName: 'Document.pdf',
-          fileSize: 2048576, // 2.00 MB
-          peers: [
-            { id: 'peer3', nickname: 'CharlieShare', reputation: 4.2, status: 'away', connection: 'slow' },
-            { id: 'peer4', nickname: 'DataVault', reputation: 4.6, status: 'online', connection: 'fast' }
-          ]
-        },
-        'QmZ4tDuvesekqMG': {
-          fileName: 'Archive.zip',
-          fileSize: 10485760, // 10.00 MB
-          peers: [
-            { id: 'peer1', nickname: 'AliceNode', reputation: 4.8, status: 'online', connection: 'fast' },
-            { id: 'peer5', nickname: 'CloudSync', reputation: 3.9, status: 'online', connection: 'average' }
-          ]
-        },
-        // New files (not in downloads list yet)
-        'QmZ4tDuvesekqMA': {
-          fileName: 'music_album.zip',
-          fileSize: 89234567,
-          peers: [
-            { id: 'peer2', nickname: 'BobStorage', reputation: 4.5, status: 'online', connection: 'average' },
-            { id: 'peer5', nickname: 'CloudSync', reputation: 3.9, status: 'online', connection: 'average' }
-          ]
-        },
-        'QmZ4tDuvesekqMB': {
-          fileName: 'software_package.deb',
-          fileSize: 12456789,
-          peers: [
-            { id: 'peer1', nickname: 'AliceNode', reputation: 4.8, status: 'online', connection: 'fast' },
-            { id: 'peer3', nickname: 'CharlieShare', reputation: 4.2, status: 'away', connection: 'slow' },
-            { id: 'peer4', nickname: 'DataVault', reputation: 4.6, status: 'online', connection: 'fast' }
-          ]
-        },
-        'QmZ4tDuvesekqMC': {
-          fileName: 'presentation.pptx',
-          fileSize: 5242880, // 5.00 MB
-          peers: [
-            { id: 'peer2', nickname: 'BobStorage', reputation: 4.5, status: 'online', connection: 'average' },
-            { id: 'peer4', nickname: 'DataVault', reputation: 4.6, status: 'online', connection: 'fast' }
-          ]
-        },
-        'QmZ4tDuvesekqME': {
-          fileName: 'game_assets.tar.gz',
-          fileSize: 156789123,
-          peers: [
-            { id: 'peer1', nickname: 'AliceNode', reputation: 4.8, status: 'online', connection: 'fast' },
-            { id: 'peer2', nickname: 'BobStorage', reputation: 4.5, status: 'online', connection: 'average' },
-            { id: 'peer3', nickname: 'CharlieShare', reputation: 4.2, status: 'away', connection: 'slow' },
-            { id: 'peer5', nickname: 'CloudSync', reputation: 3.9, status: 'online', connection: 'average' }
-          ]
-        }
-      }
-
-      // Check if the searched hash exists in our mock database
-      const fileData = mockFileDatabase[searchHash]
-
-      let mockResults = []
-      if (fileData) {
-        // File found - create mock result
-        const seeders = fileData.peers.length
-        const leechers = Math.floor(Math.random() * 3) // Random leechers
-
-        mockResults = [{
-          fileHash: searchHash,
-          fileName: fileData.fileName,
-          fileSize: fileData.fileSize,
-          seeders: seeders,
-          leechers: leechers,
-          peers: fileData.peers
-        }]
-      }
-      // If fileData is undefined, mockResults stays empty (no files found)
-
-      searchResults = mockResults
-      hasSearched = true
-      showNotification(`Found ${mockResults.length} result(s) for your search`, 'success')
-
+      await dhtService.searchFile(trimmed)
     } catch (error) {
       console.error('Search failed:', error)
-      searchResults = []
-      hasSearched = true
       const errorMessage = error instanceof Error ? error.message : 'Unknown error'
       showNotification(`Search failed: ${errorMessage}`, 'error', 6000)
-    } finally {
       isSearching = false
+      hasSearched = true
     }
   }
 
   // New function to download from search results
-  async function downloadFromSearchResult(result: any) {
+  async function downloadFromSearchResult(result: SearchResult) {
     // Check for duplicates using the existing logic
     const allFiles = [...$files, ...$downloadQueue]
     const existingFile = allFiles.find(f => f.hash === result.fileHash)
@@ -500,107 +501,26 @@
     searchResults = []
     hasSearched = false
     searchHash = ''
-  }
-
-  // Enhanced startDownload function with real P2P download (kept for backward compatibility)
-  async function startDownload() {
-    if (!searchHash) {
-      showNotification(tr('download.notifications.enterHash'), 'warning')
-      return
-    }
-    
-    // Check for ALL duplicates (including uploaded files)
-    const allFiles = [...$files, ...$downloadQueue]
-    const existingFile = allFiles.find(f => f.hash === searchHash)
-
-    if (existingFile) {
-      // Handle different scenarios
-      if (existingFile.status === 'seeding' || existingFile.status === 'uploaded') {
-        // User is trying to download a file they're already sharing
-        // Show warning but proceed anyway
-        showNotification('Downloading file that you are already sharing', 'warning', 3000);
-        
-      } else {
-        // File is already in download queue/completed/etc.
-        showNotification('File is already in your download list', 'warning')
-        return
-      }
-    }
-    
-    try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      
-      // Step 1: Show search start notification
-      showNotification(tr('download.notifications.searching'), 'info', 2000)
-      
-      // Step 2: Start file transfer service if not already running
-      try {
-        await invoke('start_file_transfer_service');
-      } catch (e) {
-        console.log('File transfer service already running or error:', e);
-      }
-      
-      // Step 3: Search for file in DHT
-      try {
-        await invoke('search_file_metadata', { fileHash: searchHash });
-        // Wait a moment for DHT search to complete
-        await new Promise(resolve => setTimeout(resolve, 2000));
-      } catch (e) {
-        console.log('DHT search failed:', e);
-      }
-      
-      // Step 4: Skip validation for now - let download fail naturally
-      // This avoids Tauri initialization issues
-      // The download will fail later in simulateDownloadProgress if needed
-      
-      // Step 5: Create new download item and add to queue
-      const newFile = {
-        id: `download-${Date.now()}`,
-        name: 'File_' + searchHash.substring(0, 8) + '.dat',
-        hash: searchHash,
-        size: 0, // Will be updated when we get file info
-        price: 0, // No price in this implementation
-        status: 'queued' as const,
-        priority: 'normal' as const
-      }
-      
-      downloadQueue.update(q => [...q, newFile])
-      
-      // Step 6: Show download start notification
-      showNotification(tr('download.notifications.addedToQueue'), 'success')
-      
-      if (autoStartQueue) {
-        processQueue()
-        // Don't show "automatically started" message immediately
-        // It will be shown in simulateDownloadProgress if download actually starts
-      }
-      
-      // Clear input
-      searchHash = ''
-      
-    } catch (error) {
-      // Error handling
-      console.error('Search download failed:', error)
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
-      showNotification(tr('download.notifications.searchFailed', { values: { error: errorMessage } }), 'error', 6000)
-    }
+    pendingSearchHash = null
   }
 
   // Function to clear search
-function clearSearch() {
-  searchHash = ''
-}
+  function clearSearch() {
+    searchHash = ''
+    pendingSearchHash = null
+  }
 
   function processQueue() {
-    // Only prevent starting new downloads if we've reached the max concurrent limit
-    const activeDownloads = $files.filter(f => f.status === 'downloading').length
-    // Handle case where maxConcurrentDownloads might be empty during typing
+    const activeDownloads = get(files).filter(f => f.status === 'downloading').length
     const maxConcurrent = Math.max(1, Number(maxConcurrentDownloads) || 3)
     if (activeDownloads >= maxConcurrent) return
 
-    const nextFile = $downloadQueue[0]
-    if (!nextFile) return
-    downloadQueue.update(q => q.filter(f => f.id !== nextFile.id))
+    const queueSnapshot = get(downloadQueue)
+    if (queueSnapshot.length === 0) return
+
+    const [nextFile, ...rest] = queueSnapshot
+    downloadQueue.set(rest)
+
     const downloadingFile = { ...nextFile, status: 'downloading' as const, progress: 0 }
     files.update(f => [...f, downloadingFile])
     simulateDownloadProgress(downloadingFile.id)
@@ -639,95 +559,75 @@ function clearSearch() {
   }
   
   async function simulateDownloadProgress(fileId: string) {
-    // Prevent duplicate simulations
     if (activeSimulations.has(fileId)) {
+      return
+    }
+
+    const snapshot = get(files)
+    const fileToDownload = snapshot.find(f => f.id === fileId)
+    if (!fileToDownload) {
       return
     }
 
     activeSimulations.add(fileId)
 
-    // Get the file to download
-    const fileToDownload = $files.find(f => f.id === fileId);
-    if (!fileToDownload) {
-      activeSimulations.delete(fileId);
-      return;
-    }
-
-    // Proceed directly to file dialog
     try {
-      const { invoke } = await import('@tauri-apps/api/core');
-      const { save } = await import('@tauri-apps/plugin-dialog');
-      
-      // Show file save dialog
+      const { save } = await import('@tauri-apps/plugin-dialog')
+
       const outputPath = await save({
         defaultPath: fileToDownload.name,
-        filters: [{
-          name: 'All Files',
-          extensions: ['*']
-        }]
-      });
-      
-      if (!outputPath) {
-        // User cancelled the save dialog
-        activeSimulations.delete(fileId);
-        files.update(f => f.map(file => 
-          file.id === fileId 
-            ? { ...file, status: 'canceled' }
-            : file
-        ));
-        return;
-      }
-      
-      // Show "automatically started" message now that download is proceeding
-      showNotification(tr('download.notifications.autostart'), 'info');
-      
-      // Start the actual download
-      files.update(f => f.map(file => 
-        file.id === fileId ? { ...file, progress: 10 } : file
-      ));
-      
-      // Simulate progress while downloading - complete when progress reaches 100%
-      const progressInterval = setInterval(() => {
-        files.update(f => f.map(file => {
-          if (file.id === fileId && file.status === 'downloading') {
-            const currentProgress = file.progress || 10;
-            const newProgress = Math.min(100, currentProgress + Math.random() * 8 + 2); // 2-10% increment
-
-            // Check if download just completed
-            if (newProgress >= 100) {
-              // Complete the download
-              clearInterval(progressInterval);
-              activeSimulations.delete(fileId);
-              showNotification(`Download completed: ${fileToDownload.name} saved to ${outputPath}`, 'success');
-
-              return { ...file, progress: 100, status: 'completed', downloadPath: outputPath };
-            }
-
-            return { ...file, progress: newProgress };
+        filters: [
+          {
+            name: 'All Files',
+            extensions: ['*']
           }
-          return file;
-        }));
+        ]
+      })
 
-        // Check if download was cancelled (cleanup if needed)
-        const currentFile = $files.find(f => f.id === fileId);
-        if (!currentFile || currentFile.status === 'canceled') {
-          clearInterval(progressInterval);
-          activeSimulations.delete(fileId);
-        }
-      }, 500);
-      
+      if (!outputPath) {
+        files.update(f =>
+          f.map(file =>
+            file.id === fileId
+              ? { ...file, status: 'canceled' as const }
+              : file
+          )
+        )
+        return
+      }
+
+      showNotification(tr('download.notifications.autostart'), 'info')
+
+      const resolvedPath = await fileService.downloadFile(
+        fileToDownload.hash,
+        fileToDownload.name,
+        outputPath
+      )
+
+      files.update(f =>
+        f.map(file =>
+          file.id === fileId
+            ? { ...file, progress: 100, status: 'completed' as const, downloadPath: resolvedPath }
+            : file
+        )
+      )
+
+      showNotification(`Download completed: ${fileToDownload.name}`, 'success')
     } catch (error) {
-      // Download failed
-      activeSimulations.delete(fileId);
-      
-      files.update(f => f.map(file => 
-        file.id === fileId 
-          ? { ...file, status: 'failed' }
-          : file
-      ));
-      
-      console.error('Download failed:', error);
-      showNotification(tr('download.notifications.downloadFailed', { values: { name: fileToDownload.name } }), 'error');
+      console.error('Download failed:', error)
+      files.update(f =>
+        f.map(file =>
+          file.id === fileId
+            ? { ...file, status: 'failed' as const }
+            : file
+        )
+      )
+      showNotification(
+        tr('download.notifications.downloadFailed', { values: { name: fileToDownload.name } }),
+        'error'
+      )
+    } finally {
+      activeSimulations.delete(fileId)
+      processQueue()
     }
   }
   
@@ -868,30 +768,9 @@ function clearSearch() {
                       </div>
                     </div>
 
-                    <!-- Peer list spanning full width -->
-                    <details class="text-xs mt-2 ml-7">
-                      <summary class="cursor-pointer text-muted-foreground hover:text-foreground">
-                        View available peers
-                      </summary>
-                      <div class="mt-2 space-y-1">
-                        {#each result.peers as peer}
-                          <div class="flex items-center py-1">
-                            <span class="text-sm text-foreground mr-1">•</span>
-                            <span class="text-sm text-foreground">{peer.nickname}</span>
-                            <div class="flex items-center gap-2 ml-3">
-                              <Badge variant="outline" class="text-xs border-yellow-400 text-yellow-600">
-                                <Star class="h-3 w-3 mr-1 fill-yellow-400 text-yellow-400" />
-                                {peer.reputation}
-                              </Badge>
-                              <Badge variant="outline" class="text-xs {peer.connection === 'fast' ? 'border-green-500 text-green-600' : peer.connection === 'average' ? 'border-yellow-400 text-yellow-600' : 'border-red-500 text-red-600'}">
-                                <Zap class="h-3 w-3 mr-1 {peer.connection === 'fast' ? 'fill-green-500 text-green-500' : peer.connection === 'average' ? 'fill-yellow-400 text-yellow-400' : 'text-red-500 fill-red-500'}" />
-                                {peer.connection}
-                              </Badge>
-                            </div>
-                          </div>
-                        {/each}
-                      </div>
-                    </details>
+                    <p class="text-xs text-muted-foreground mt-2 ml-7">
+                      Peer details will appear as the network reports them.
+                    </p>
                   </div>
                 {/each}
               </div>

--- a/src/pages/Proxy.svelte
+++ b/src/pages/Proxy.svelte
@@ -4,7 +4,7 @@
   import Input from '$lib/components/ui/input.svelte'
   import Label from '$lib/components/ui/label.svelte'
   import Badge from '$lib/components/ui/badge.svelte'
-  import { Shield, ShieldCheck, ShieldX, Globe, Activity, Plus, Power, Trash2 } from 'lucide-svelte'
+  import { ShieldCheck, ShieldX, Globe, Activity, Plus, Power, Trash2 } from 'lucide-svelte'
   import { proxyNodes } from '$lib/stores'
   import { t } from 'svelte-i18n'
   import DropDown from '$lib/components/ui/dropDown.svelte'

--- a/src/pages/Upload.svelte
+++ b/src/pages/Upload.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Card from '$lib/components/ui/card.svelte'
   import Badge from '$lib/components/ui/badge.svelte'
-  import { File as FileIcon, X, Plus, FolderOpen, FileText, Image, Music, Video, Archive, Code, FileSpreadsheet, Zap, Upload, Download, RefreshCw } from 'lucide-svelte'
+  import { File as FileIcon, X, Plus, FolderOpen, FileText, Image, Music, Video, Archive, Code, FileSpreadsheet, Upload, Download, RefreshCw } from 'lucide-svelte'
   import { files } from '$lib/stores'
   import { t } from 'svelte-i18n';
   import { get } from 'svelte/store'
@@ -160,14 +160,13 @@
     let addedCount = 0
 
     for (let i = 0; i < filesToAdd.length; i++) {
-      const file = filesToAdd[i];
+      const file = filesToAdd[i]
       try {
-        // Mock upload for demo purposes (backend not available)
-        const fileHash = `mock-hash-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+        const fileHash = await fileService.uploadFile(file)
 
         if (isDuplicateHash(get(files), fileHash)) {
           duplicateCount++
-          continue;
+          continue
         }
 
         const newFile = {
@@ -176,16 +175,19 @@
           hash: fileHash,
           size: file.size,
           status: 'seeding' as const,
-          seeders: Math.floor(Math.random() * 10) + 1,
-          leechers: Math.floor(Math.random() * 5),
+          seeders: 1,
+          leechers: 0,
           uploadDate: new Date()
-        };
+        }
 
-        files.update(f => [...f, newFile]);
-        addedCount++;
+        files.update(f => [...f, newFile])
+        addedCount++
       } catch (error) {
-        console.error(`Failed to upload file "${file.name}":`, error);
-        showToast(tr('upload.fileFailed', { values: { name: file.name, error: String(error) } }), 'error');
+        console.error(`Failed to upload file "${file.name}":`, error)
+        showToast(
+          tr('upload.fileFailed', { values: { name: file.name, error: String(error) } }),
+          'error'
+        )
       }
     }
 
@@ -195,7 +197,7 @@
 
     if (addedCount > 0) {
       showToast(tr('upload.filesAdded', { values: { count: addedCount } }), 'success')
-      refreshAvailableStorage()
+      await refreshAvailableStorage()
     }
   }
   


### PR DESCRIPTION
## Summary
- connect the upload page to the Tauri file service so files are seeded with real hashes and storage totals refresh from the backend
- replace the download mocks with DHT-driven search results and queue management that streams files via the Rust service
- upgrade the Rust file transfer service to persist chunked manifests on disk and expose synchronous responses for uploads and downloads

## Testing
- `npm run check`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: missing system library `glib-2.0` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1904d1c3c83248d5f885324947b85