### PR TITLE
Implement automatic geolocation detection

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,16 +12,18 @@
     import ReputationPage from './pages/Reputation.svelte'
     import NotFound from './pages/NotFound.svelte'
     import ProxySelfTest from './routes/proxy-self-test.svelte'
-    import { networkStatus } from './lib/stores'
+    import { networkStatus, settings, userLocation } from './lib/stores'
     import { Router, type RouteConfig, goto } from '@mateothegreat/svelte5-router';
     import {onMount, setContext} from 'svelte';
     import { tick } from 'svelte';
+    import { get } from 'svelte/store';
     import { setupI18n } from './i18n/i18n';
     import { t } from 'svelte-i18n';
     import SimpleToast from './lib/components/SimpleToast.svelte';
     import { startNetworkMonitoring } from './lib/services/networkService';
     import { fileService } from '$lib/services/fileService';
     import { bandwidthScheduler } from '$lib/services/bandwidthScheduler';
+    import { detectUserRegion } from '$lib/services/geolocation';
     // gets path name not entire url:
     // ex: http://locatlhost:1420/download -> /download
     
@@ -47,6 +49,56 @@
         // setup i18n
         await setupI18n();
         loading = false;
+
+        let storedLocation: string | null = null;
+        try {
+          const storedSettings = localStorage.getItem('chiralSettings');
+          if (storedSettings) {
+            const parsed = JSON.parse(storedSettings);
+            if (typeof parsed?.userLocation === 'string' && parsed.userLocation) {
+              storedLocation = parsed.userLocation;
+              userLocation.set(parsed.userLocation);
+            }
+          }
+        } catch (error) {
+          console.warn('Failed to load stored user location:', error);
+        }
+
+        try {
+          const currentLocation = get(userLocation);
+          const shouldAutoDetect = !storedLocation || currentLocation === 'US-East';
+
+          if (shouldAutoDetect) {
+            const detection = await detectUserRegion();
+            const detectedLocation = detection.region.label;
+
+            if (detectedLocation && detectedLocation !== currentLocation) {
+              userLocation.set(detectedLocation);
+
+              settings.update((previous) => {
+                const next = { ...previous, userLocation: detectedLocation };
+
+                try {
+                  const storedSettings = localStorage.getItem('chiralSettings');
+                  if (storedSettings) {
+                    const parsed = JSON.parse(storedSettings) ?? {};
+                    parsed.userLocation = detectedLocation;
+                    localStorage.setItem('chiralSettings', JSON.stringify(parsed));
+                  } else {
+                    localStorage.setItem('chiralSettings', JSON.stringify(next));
+                  }
+                } catch (storageError) {
+                  console.warn('Failed to persist detected location:', storageError);
+                }
+
+                console.log(`User region detected via ${detection.source}: ${detectedLocation}`);
+                return next;
+              });
+            }
+          }
+        } catch (error) {
+          console.warn('Automatic location detection failed:', error);
+        }
 
         // Initialize backend services (File Transfer, DHT)
         try {

--- a/src/lib/services/geolocation.ts
+++ b/src/lib/services/geolocation.ts
@@ -1,0 +1,147 @@
+import { GEO_REGIONS, UNKNOWN_REGION_ID, type GeoRegionConfig } from '$lib/geo';
+
+export type GeolocationSource = 'browser' | 'timezone' | 'fallback';
+
+export interface GeolocationResult {
+  region: GeoRegionConfig;
+  source: GeolocationSource;
+}
+
+const REGION_CANDIDATES = GEO_REGIONS.filter((region) => region.id !== UNKNOWN_REGION_ID);
+
+const FALLBACK_REGION = REGION_CANDIDATES.find((region) => region.id === 'usEast') ?? REGION_CANDIDATES[0];
+
+function toRadians(value: number): number {
+  return (value * Math.PI) / 180;
+}
+
+function haversineDistance(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371; // Radius of Earth in km
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function nearestRegion(lat: number, lng: number): GeoRegionConfig {
+  let closest = FALLBACK_REGION;
+  let minDistance = Number.POSITIVE_INFINITY;
+
+  for (const region of REGION_CANDIDATES) {
+    const distance = haversineDistance(lat, lng, region.lat, region.lng);
+    if (distance < minDistance) {
+      minDistance = distance;
+      closest = region;
+    }
+  }
+
+  return closest;
+}
+
+function inferRegionFromTimezone(timezone: string): GeoRegionConfig | null {
+  const tz = timezone.toLowerCase();
+
+  const matchers: Array<{ test: (tz: string) => boolean; regionId: string }> = [
+    {
+      test: (value) =>
+        /america\/(los_angeles|vancouver|whitehorse|sitka|anchorage|metlakatla|juneau|yakutat|tijuana|phoenix|boise|denver|edmonton|dawson|hermosillo|mazatlan)/.test(
+          value
+        ),
+      regionId: 'usWest',
+    },
+    {
+      test: (value) => /america\//.test(value),
+      regionId: 'usEast',
+    },
+    {
+      test: (value) => /europe\//.test(value),
+      regionId: 'euWest',
+    },
+    {
+      test: (value) => /(asia|indian)\//.test(value),
+      regionId: 'asiaPacific',
+    },
+    {
+      test: (value) => /(australia|pacific)\//.test(value),
+      regionId: 'oceania',
+    },
+    {
+      test: (value) => /africa\//.test(value),
+      regionId: 'africa',
+    },
+    {
+      test: (value) => /(america|south_america)\/(argentina|buenos_aires|santiago|sao_paulo|bogota|lima|la_paz|montevideo)/.test(value),
+      regionId: 'southAmerica',
+    },
+  ];
+
+  for (const matcher of matchers) {
+    if (matcher.test(tz)) {
+      const region = REGION_CANDIDATES.find((item) => item.id === matcher.regionId);
+      if (region) {
+        return region;
+      }
+    }
+  }
+
+  return null;
+}
+
+async function detectFromBrowserGeolocation(): Promise<GeoRegionConfig | null> {
+  if (typeof window === 'undefined' || !('geolocation' in navigator)) {
+    return null;
+  }
+
+  try {
+    const position = await new Promise<GeolocationPosition>((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: false,
+        maximumAge: 60_000,
+        timeout: 5_000,
+      });
+    });
+
+    const { latitude, longitude } = position.coords;
+    return nearestRegion(latitude, longitude);
+  } catch (error) {
+    console.warn('Geolocation permission denied or unavailable:', error);
+    return null;
+  }
+}
+
+function detectFromTimezone(): GeoRegionConfig | null {
+  if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat === 'undefined') {
+    return null;
+  }
+
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (!timezone) {
+    return null;
+  }
+
+  return inferRegionFromTimezone(timezone);
+}
+
+export async function detectUserRegion(): Promise<GeolocationResult> {
+  const browserRegion = await detectFromBrowserGeolocation();
+  if (browserRegion) {
+    return { region: browserRegion, source: 'browser' };
+  }
+
+  const timezoneRegion = detectFromTimezone();
+  if (timezoneRegion) {
+    return { region: timezoneRegion, source: 'timezone' };
+  }
+
+  return { region: FALLBACK_REGION, source: 'fallback' };
+}
+
+export function calculateRegionDistance(a: GeoRegionConfig, b: GeoRegionConfig): number {
+  return haversineDistance(a.lat, a.lng, b.lat, b.lng);
+}

--- a/src/pages/Network.svelte
+++ b/src/pages/Network.svelte
@@ -8,6 +8,7 @@
   import PeerMetrics from '$lib/components/PeerMetrics.svelte'
   import GeoDistributionCard from '$lib/components/GeoDistributionCard.svelte'
   import { peers, networkStats, networkStatus, userLocation, etcAccount, settings } from '$lib/stores'
+  import { normalizeRegion, UNKNOWN_REGION_ID } from '$lib/geo'
   import { Users, HardDrive, Activity, RefreshCw, UserPlus, Signal, Server, Play, Square, Download, AlertCircle, Wifi, UserMinus } from 'lucide-svelte'
   import { get } from 'svelte/store'
   import { onMount, onDestroy } from 'svelte'
@@ -24,6 +25,8 @@
   import { SignalingService } from '$lib/services/signalingService';
   import { createWebRTCSession } from '$lib/services/webrtcService';
   import { peerDiscoveryStore, startPeerEventStream, type PeerDiscovery } from '$lib/services/peerEventService';
+  import type { GeoRegionConfig } from '$lib/geo';
+  import { calculateRegionDistance } from '$lib/services/geolocation';
 
 
   // Check if running in Tauri environment
@@ -41,6 +44,11 @@
   let newPeerAddress = ''
   let sortBy: 'reputation' | 'sharedFiles' | 'totalSize' | 'nickname' | 'location' | 'joinDate' | 'lastSeen' | 'status' = 'reputation'
   let sortDirection: 'asc' | 'desc' = 'desc'
+
+  const UNKNOWN_DISTANCE = 1_000_000;
+
+  let currentUserRegion: GeoRegionConfig = normalizeRegion(undefined);
+  $: currentUserRegion = normalizeRegion($userLocation);
   
   // Update sort direction when category changes to match the default
   $: if (sortBy) {
@@ -1984,23 +1992,26 @@
                     bVal = (b.nickname || 'zzzzz').toLowerCase()
                     break
                 case 'location':
-                    aVal = (a.location || 'zzzzz').toLowerCase() // Put empty locations at the end
-                    bVal = (b.location || 'zzzzz').toLowerCase()
-                    // Distance-based sorting: closer peers first
                     const getLocationDistance = (peerLocation: string | undefined) => {
-                        if (!peerLocation) return 999; // Unknown locations go to the end
-                        
-                        // Distance map from user's location to other regions
-                        const distanceMap: Record<string, Record<string, number>> = {
-                            'US-East': { 'US-East': 0, 'US-West': 1, 'EU-West': 2, 'Asia-Pacific': 3 },
-                            'US-West': { 'US-West': 0, 'US-East': 1, 'EU-West': 3, 'Asia-Pacific': 2 },
-                            'EU-West': { 'EU-West': 0, 'US-East': 1, 'US-West': 3, 'Asia-Pacific': 2 },
-                            'Asia-Pacific': { 'Asia-Pacific': 0, 'US-West': 1, 'EU-West': 2, 'US-East': 3 }
-                        };
-                        
-                        return distanceMap[$userLocation]?.[peerLocation] ?? 999;
+                        if (!peerLocation) return UNKNOWN_DISTANCE;
+
+                        const peerRegion = normalizeRegion(peerLocation);
+
+                        if (peerRegion.id === UNKNOWN_REGION_ID) {
+                            return UNKNOWN_DISTANCE;
+                        }
+
+                        if (currentUserRegion.id === UNKNOWN_REGION_ID) {
+                            return peerRegion.id === UNKNOWN_REGION_ID ? 0 : UNKNOWN_DISTANCE;
+                        }
+
+                        if (peerRegion.id === currentUserRegion.id) {
+                            return 0;
+                        }
+
+                        return Math.round(calculateRegionDistance(currentUserRegion, peerRegion));
                     };
-                    
+
                     aVal = getLocationDistance(a.location);
                     bVal = getLocationDistance(b.location);
                     break

--- a/src/pages/Settings.svelte
+++ b/src/pages/Settings.svelte
@@ -20,6 +20,7 @@
   import { homeDir } from "@tauri-apps/api/path";
   import { getVersion } from "@tauri-apps/api/app";
   import { userLocation } from "$lib/stores";
+  import { GEO_REGIONS, UNKNOWN_REGION_ID } from "$lib/geo";
   import { changeLocale, loadLocale } from "../i18n/i18n";
   import { t } from "svelte-i18n";
   import { get } from "svelte/store";
@@ -94,12 +95,10 @@
   let autonatServersText = '';
   let preferredRelaysText = '';
 
-  const locations = [
-    { value: "US-East", label: "US East" },
-    { value: "US-West", label: "US West" },
-    { value: "EU-West", label: "Europe West" },
-    { value: "Asia-Pacific", label: "Asia Pacific" },
-  ];
+  const locationOptions = GEO_REGIONS
+    .filter((region) => region.id !== UNKNOWN_REGION_ID)
+    .map((region) => ({ value: region.label, label: region.label }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   let languages = [];
   $: languages = [
@@ -617,7 +616,7 @@ function sectionMatches(section: string, query: string) {
           <Label for="user-location">{$t("network.userLocation")}</Label>
           <DropDown
             id="user-location"
-            options={locations}
+            options={locationOptions}
             bind:value={localSettings.userLocation}
           />
           <p class="text-xs text-muted-foreground mt-1">


### PR DESCRIPTION
## Summary
- add a geolocation service that resolves the nearest network region from browser coordinates or timezone data
- automatically populate and persist the detected region on startup while leaving user overrides intact
- expand location-aware sorting and settings options to use the full region catalog and real distance calculations

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68eeb34ca5d083249c00569af22c06ae